### PR TITLE
test: Adds edge case tests for invalid input data

### DIFF
--- a/tests/functional/test_edge_cases.py
+++ b/tests/functional/test_edge_cases.py
@@ -14,3 +14,20 @@ def test_fit_on_empty_dataset():
     # 2 & 3. ACT & ASSERT (Wykonanie i weryfikacja błędu)
     with pytest.raises(ValueError):
         model.fit(X_empty, y_empty)
+
+def test_fit_shape_mismatch():
+    """
+    Sprawdza odporność algorytmu na błędne wymiary danych wejściowych.
+    Upewnia się, że podanie różnej liczby próbek (X) i etykiet (y)
+    skutkuje wyrzuceniem błędu ValueError.
+    """
+    # 1. ARRANGE (Przygotowanie zepsutych danych)
+    model = RandomForestClassifier(n_estimators=10, random_state=42)
+    
+    # 3 wiersze danych (cech), ale tylko 2 odpowiedzi (etykiety)
+    X_bad_shape = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+    y_bad_shape = [0, 1]
+    
+    # 2 & 3. ACT & ASSERT (Sprawdzenie, czy model to zablokuje)
+    with pytest.raises(ValueError):
+        model.fit(X_bad_shape, y_bad_shape)

--- a/tests/functional/test_edge_cases.py
+++ b/tests/functional/test_edge_cases.py
@@ -1,0 +1,16 @@
+import pytest
+from sklearn.ensemble import RandomForestClassifier
+
+def test_fit_on_empty_dataset():
+    """
+    Sprawdza, czy próba trenowania modelu na całkowicie pustych listach
+    (brak danych) zostaje bezpiecznie przechwycona i rzuca wyjątek ValueError.
+    """
+    # 1. ARRANGE (Przygotowanie pustych danych i modelu)
+    model = RandomForestClassifier(n_estimators=10, random_state=42)
+    X_empty = []
+    y_empty = []
+    
+    # 2 & 3. ACT & ASSERT (Wykonanie i weryfikacja błędu)
+    with pytest.raises(ValueError):
+        model.fit(X_empty, y_empty)


### PR DESCRIPTION
### Description of changes
This Pull Request introduces edge case tests (so-called "sad paths") for `scikit-learn` models. The goal is to verify whether the library correctly and safely handles invalid input data, raising expected exceptions instead of crashing the application.

**Implementation details (`tests/functional/test_edge_cases.py`):**
1. `test_fit_on_empty_dataset`: Verifies that a `ValueError` is correctly raised when attempting to call the `.fit()` method on completely empty datasets.
2. `test_fit_shape_mismatch`: Verifies that a `ValueError` is raised in case of a shape mismatch (different number of samples in `X` and labels in `y`).